### PR TITLE
chore: add dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "08:00"
+      timezone: "Australia/Perth"


### PR DESCRIPTION
## Summary

Adds Dependabot configuration to automatically monitor and update GitHub Actions dependencies used in this repository.

## Changes

- Add `.github/dependabot.yml` configuring weekly checks for the `github-actions` ecosystem
- Schedule set to Fridays at 08:00 AWST (Australia/Perth timezone)