### PR TITLE
chore: add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: rsclarke
+thanks_dev: u/gh/rsclarke


### PR DESCRIPTION
## Summary

Adds a GitHub funding configuration to enable the Sponsor button on the repository, linking to GitHub Sponsors and thanks.dev.

## Changes

- Add `.github/FUNDING.yml` with `github` and `thanks_dev` funding links