### PR TITLE
chore: switch to immutable releases for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This GitHub Action installs [go-task/task](https://github.com/go-task/task) to the GitHub Actions runner tool cache and adds it to the PATH. It **always** verifies the downloaded archive against official checksums.
 
+## Versioning
+
+From **v2.0.0** onwards this action uses **immutable releases** with full semantic versioning (`vMAJOR.MINOR.PATCH`). Floating major tags (e.g., `v2`) are **not** provided.
+
+When referencing this action, either use the full version string or pin to a commit SHA:
+
+```yaml
+# Full version string
+uses: rsclarke/install-task@v2.0.0
+
+# Pinned to SHA (recommended)
+uses: rsclarke/install-task@<COMMIT_SHA> # v2.0.0
+```
+
 ## Platform Support
 
 This action supports **Linux** and **macOS** runners only. Windows is not supported.
@@ -35,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Task
-        uses: rsclarke/install-task@v1
+        uses: rsclarke/install-task@v2.0.0
 
       - name: Run Task
         run: task --list

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,7 @@
 version: "3"
 
 vars:
+  RELEASE_BRANCH: '{{default "main" .RELEASE_BRANCH}}'
   CURRENT_VERSION:
     sh: git describe --tags --match 'v*.*.*' --abbrev=0 2>/dev/null || echo "v0.0.0"
   MAJOR:
@@ -16,99 +17,78 @@ vars:
   NEXT_MAJOR:
     sh: echo $(({{.MAJOR}} + 1))
 
-  # Version strings
   NEW_PATCH_VERSION: "v{{.MAJOR}}.{{.MINOR}}.{{.NEXT_PATCH}}"
-  CURRENT_MINOR_ALIAS: "v{{.MAJOR}}.{{.MINOR}}"
-  CURRENT_MAJOR_ALIAS: "v{{.MAJOR}}"
-
   NEW_MINOR_VERSION: "v{{.MAJOR}}.{{.NEXT_MINOR}}.0"
-  NEW_MINOR_ALIAS: "v{{.MAJOR}}.{{.NEXT_MINOR}}"
-
   NEW_MAJOR_VERSION: "v{{.NEXT_MAJOR}}.0.0"
-  NEW_MAJOR_ALIAS: "v{{.NEXT_MAJOR}}"
-  NEW_MAJOR_MINOR_ALIAS: "v{{.NEXT_MAJOR}}.0"
 
 tasks:
+  _preflight:
+    internal: true
+    desc: Validate branch and remote state before releasing
+    cmds:
+      - |
+        branch=$(git symbolic-ref --quiet --short HEAD) || {
+          echo "Refusing to release from detached HEAD"; exit 1
+        }
+        [ "$branch" = "{{.RELEASE_BRANCH}}" ] || {
+          echo "Refusing to release from '$branch' (expected {{.RELEASE_BRANCH}})"; exit 1
+        }
+      - git fetch origin --tags --prune
+      - |
+        [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/{{.RELEASE_BRANCH}})" ] || {
+          echo "Refusing to release: HEAD is not at origin/{{.RELEASE_BRANCH}}"; exit 1
+        }
+
   _tag:create:
     internal: true
     desc: Helper to create and push a git tag
     cmds:
-      - git tag -s -a "{{.TAG}}" -m "{{.MESSAGE}}"
+      - git tag -s "{{.TAG}}" -m "{{.MESSAGE}}"
       - git push origin "{{.TAG}}"
 
-  _tag:update:
-    internal: true
-    desc: Helper to update an existing tag to point to the current commit
-    cmds:
-      - git tag -s -fa "{{.TAG}}" -m "{{.MESSAGE}}"
-      - git push -f origin "{{.TAG}}"
-
   version:patch:
-    desc: Create a new patch version tag and update alias tags
+    desc: Create a new patch version tag
     cmds:
+      - task: _preflight
       - task: _tag:create
         vars:
           TAG: "{{.NEW_PATCH_VERSION}}"
           MESSAGE: "Release {{.NEW_PATCH_VERSION}}"
 
-      # Update the minor alias to point to this commit
-      - task: _tag:update
-        vars:
-          TAG: "{{.CURRENT_MINOR_ALIAS}}"
-          MESSAGE: "Release alias for {{.NEW_PATCH_VERSION}}"
-
-      # Update the major alias to point to this commit
-      - task: _tag:update
-        vars:
-          TAG: "{{.CURRENT_MAJOR_ALIAS}}"
-          MESSAGE: "Release alias for {{.NEW_PATCH_VERSION}}"
-
   version:minor:
-    desc: Create a new minor version tag with updated alias tags
+    desc: Create a new minor version tag
     cmds:
+      - task: _preflight
       - task: _tag:create
         vars:
           TAG: "{{.NEW_MINOR_VERSION}}"
           MESSAGE: "Release {{.NEW_MINOR_VERSION}}"
 
-      # Create the new minor alias
-      - task: _tag:create
-        vars:
-          TAG: "{{.NEW_MINOR_ALIAS}}"
-          MESSAGE: "Release alias for {{.NEW_MINOR_VERSION}}"
-
-      # Update the major alias to point to this commit
-      - task: _tag:update
-        vars:
-          TAG: "{{.CURRENT_MAJOR_ALIAS}}"
-          MESSAGE: "Release alias for {{.NEW_MINOR_VERSION}}"
-
   version:major:
-    desc: Create a new major version tag with major and minor aliases
+    desc: Create a new major version tag
     cmds:
+      - task: _preflight
       - task: _tag:create
         vars:
           TAG: "{{.NEW_MAJOR_VERSION}}"
           MESSAGE: "Release {{.NEW_MAJOR_VERSION}}"
 
-      # Create the new major alias
-      - task: _tag:create
-        vars:
-          TAG: "{{.NEW_MAJOR_ALIAS}}"
-          MESSAGE: "Release alias for {{.NEW_MAJOR_VERSION}}"
-
-      # Create the new major.minor alias
-      - task: _tag:create
-        vars:
-          TAG: "{{.NEW_MAJOR_MINOR_ALIAS}}"
-          MESSAGE: "Release alias for {{.NEW_MAJOR_VERSION}}"
+  release:tag:
+    desc: Create a GitHub release for a specific tag
+    requires:
+      vars: [TAG]
+    cmds:
+      - gh release create "{{.TAG}}" --verify-tag --title "{{.TAG}}" --generate-notes
 
   release:latest:
     desc: Create a GitHub release for the latest tag
+    vars:
+      LATEST_TAG:
+        sh: git describe --tags --match 'v*.*.*' --abbrev=0
     cmds:
-      - |
-        LATEST_TAG=$(git describe --tags --match 'v*.*.*' --abbrev=0)
-        gh release create "$LATEST_TAG" --title "Release $LATEST_TAG" --generate-notes
+      - task: release:tag
+        vars:
+          TAG: "{{.LATEST_TAG}}"
 
   release:patch:
     desc: Create a new patch version and release it on GitHub
@@ -117,13 +97,13 @@ tasks:
       - task: release:latest
 
   release:minor:
-    desc: Create a new minor version (with aliases) and release it on GitHub
+    desc: Create a new minor version and release it on GitHub
     cmds:
       - task: version:minor
       - task: release:latest
 
   release:major:
-    desc: Create a new major version (with aliases) and release it on GitHub
+    desc: Create a new major version and release it on GitHub
     cmds:
       - task: version:major
       - task: release:latest


### PR DESCRIPTION
## Summary

Switch the release workflow to immutable semver-only tags and document the new versioning policy for v2.0.0 onwards. Floating major/minor alias tags are no longer created or force-updated, aligning with the approach used in [rsclarke/setup-tenv](https://github.com/rsclarke/setup-tenv).

## Changes

- Remove floating minor and major alias tag creation and force-update logic from Taskfile
- Add `_preflight` task to validate branch and remote state before releasing
- Add `release:tag` task for creating GitHub releases by specific tag
- Add a **Versioning** section to the README documenting immutable releases and commit SHA pinning
- Update usage example to reference `v2.0.0` instead of `v1`