### PR TITLE
refactor(action)!: use github.token directly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Task
         uses: ./
-        with:
-          github-token: ${{ github.token }}
       - name: Verify task
         run: |
           which task

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ When no explicit version is provided, the latest release is resolved first so it
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `version` | Version of go-task/task to install (e.g., `v3.29.1`). If not specified, the latest release will be resolved automatically. | No | Latest |
-| `github-token` | GitHub token used to authenticate API and release download requests. Helps avoid rate limits when resolving the latest version or downloading assets. | No | `""` |
+
+The action uses the caller workflow's `GITHUB_TOKEN` automatically via `github.token`, so no token input is required.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: "Version of go-task/task to install (e.g., v3.29.1). If not specified, latest release will be used."
     required: false
     default: ""
-  github-token:
-    description: "GitHub token to use for API requests. Only needed if fetching latest version."
-    required: false
-    default: ""
 
 outputs:
   task_path:
@@ -32,13 +28,7 @@ runs:
         else
           echo "No version specified, fetching latest release..."
 
-          if [[ -n "${{ inputs.github-token }}" ]]; then
-            AUTH_HEADER="Authorization: token ${{ inputs.github-token }}"
-          else
-            AUTH_HEADER=""
-          fi
-
-          LATEST_RELEASE=$(curl -s -H "${AUTH_HEADER}" https://api.github.com/repos/go-task/task/releases/latest)
+          LATEST_RELEASE=$(curl -s -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/go-task/task/releases/latest)
 
           if [[ $? -eq 0 && -n "${LATEST_RELEASE}" ]]; then
             TASK_VERSION=$(echo "${LATEST_RELEASE}" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
@@ -116,10 +106,7 @@ runs:
         VERSION_WITHOUT_V="${{ steps.resolve-version.outputs.version-without-v }}"
 
         # Build auth header for GitHub API and release downloads
-        CURL_AUTH=()
-        if [[ -n "${{ inputs.github-token }}" ]]; then
-          CURL_AUTH=(-H "Authorization: token ${{ inputs.github-token }}")
-        fi
+        CURL_AUTH=(-H "Authorization: Bearer ${{ github.token }}")
 
         # Determine checksum command
         case "$RUNNER_OS" in


### PR DESCRIPTION
This PR simplifies the action interface by removing the explicit github-token input and using the caller workflow's github.token directly for GitHub API and release download requests. That keeps the common case zero-config, but it is a breaking change for callers that currently pass a custom token, and it updates the repo's own test workflow to match the new interface.

- Remove the github-token input from the action metadata and use github.token directly when resolving the latest Task release.
- Use github.token for authenticated release asset and checksum downloads.
- Update the README to document that the action now automatically uses the caller workflow's GITHUB_TOKEN.
- Update the repository test workflow to stop passing the removed github-token input to the local action.