### PR TITLE
fix(action): harden task download curl requests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,9 +120,6 @@ runs:
 
         mkdir -p "${INSTALL_DIR}"
 
-        # Build auth header for GitHub API and release downloads
-        CURL_AUTH=(-H "Authorization: Bearer ${{ github.token }}")
-
         # Determine checksum command
         case "$RUNNER_OS" in
           macOS) CHECKSUM_CMD="shasum -a 256" ;;
@@ -136,14 +133,14 @@ runs:
         TEMP_DIR=$(mktemp -d)
 
         echo "Downloading from: ${DOWNLOAD_URL}"
-        curl -sL "${CURL_AUTH[@]}" "${DOWNLOAD_URL}" -o "${TEMP_DIR}/task.tar.gz"
+        curl -sL "${DOWNLOAD_URL}" -o "${TEMP_DIR}/task.tar.gz"
         if [[ $? -ne 0 ]]; then
           echo "Failed to download Task from ${DOWNLOAD_URL}"
           exit 1
         fi
 
         echo "Verifying checksum..."
-        curl -sL "${CURL_AUTH[@]}" "${CHECKSUMS_URL}" -o "${TEMP_DIR}/task_checksums.txt"
+        curl -sL "${CHECKSUMS_URL}" -o "${TEMP_DIR}/task_checksums.txt"
         if [[ $? -ne 0 ]]; then
           echo "Failed to download checksums from ${CHECKSUMS_URL}"
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         else
           echo "No version specified, fetching latest release..."
 
-          LATEST_RELEASE=$(curl -s -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/go-task/task/releases/latest)
+          LATEST_RELEASE=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/go-task/task/releases/latest)
 
           if [[ $? -eq 0 && -n "${LATEST_RELEASE}" ]]; then
             TASK_VERSION=$(echo "${LATEST_RELEASE}" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
@@ -133,14 +133,14 @@ runs:
         TEMP_DIR=$(mktemp -d)
 
         echo "Downloading from: ${DOWNLOAD_URL}"
-        curl -sL "${DOWNLOAD_URL}" -o "${TEMP_DIR}/task.tar.gz"
+        curl -fsSL "${DOWNLOAD_URL}" -o "${TEMP_DIR}/task.tar.gz"
         if [[ $? -ne 0 ]]; then
           echo "Failed to download Task from ${DOWNLOAD_URL}"
           exit 1
         fi
 
         echo "Verifying checksum..."
-        curl -sL "${CHECKSUMS_URL}" -o "${TEMP_DIR}/task_checksums.txt"
+        curl -fsSL "${CHECKSUMS_URL}" -o "${TEMP_DIR}/task_checksums.txt"
         if [[ $? -ne 0 ]]; then
           echo "Failed to download checksums from ${CHECKSUMS_URL}"
           exit 1


### PR DESCRIPTION
This PR narrows authentication to the GitHub API request that resolves the latest Task release and hardens all related curl invocations to fail on HTTP errors. That keeps release asset downloads API-focused while surfacing bad responses immediately in the action.

- limit github token usage to the api.github.com latest-release lookup instead of sending it with release asset downloads
- switch the release lookup, archive download, and checksum download curl calls to -fsSL so 4xx/5xx responses fail the step