### PR TITLE
chore(action): remediate zizmor findings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,8 +27,8 @@ runs:
       id: resolve-version
       shell: bash
       run: |
-        if [[ -n "${{ inputs.version }}" ]]; then
-          TASK_VERSION="${{ inputs.version }}"
+        if [[ -n "${INPUTS_VERSION}" ]]; then
+          TASK_VERSION="${INPUTS_VERSION}"
         else
           echo "No version specified, fetching latest release..."
 
@@ -49,9 +49,16 @@ runs:
           TASK_VERSION="v${TASK_VERSION}"
         fi
 
+        if [[ ! "${TASK_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          echo "Invalid Task version: ${TASK_VERSION}"
+          exit 1
+        fi
+
         echo "Resolved Task version: ${TASK_VERSION}"
         echo "version=${TASK_VERSION}" >> $GITHUB_OUTPUT
         echo "version-without-v=${TASK_VERSION#v}" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_VERSION: ${{ inputs.version }}
 
     - name: Restore tool cache
       if: inputs.use-cache == 'true'
@@ -83,21 +90,23 @@ runs:
             ;;
         esac
 
-        VERSION_WITHOUT_V="${{ steps.resolve-version.outputs.version-without-v }}"
+        VERSION_WITHOUT_V="${STEPS_RESOLVE_VERSION_OUTPUTS_VERSION_WITHOUT_V}"
         INSTALL_DIR="${RUNNER_TOOL_CACHE}/task/${VERSION_WITHOUT_V}/${ARCH}"
 
         echo "os=${OS}" >> $GITHUB_OUTPUT
         echo "arch=${ARCH}" >> $GITHUB_OUTPUT
         echo "install-dir=${INSTALL_DIR}" >> $GITHUB_OUTPUT
+      env:
+        STEPS_RESOLVE_VERSION_OUTPUTS_VERSION_WITHOUT_V: ${{ steps.resolve-version.outputs.version-without-v }}
 
     - name: Check for cached task
       id: check-task
       if: inputs.use-cache == 'true'
       shell: bash
       run: |
-        VERSION_WITHOUT_V="${{ steps.resolve-version.outputs.version-without-v }}"
-        INSTALL_DIR="${{ steps.resolve-install-dir.outputs.install-dir }}"
-        COMPLETE_MARKER="${RUNNER_TOOL_CACHE}/task/${VERSION_WITHOUT_V}/${{ steps.resolve-install-dir.outputs.arch }}.complete"
+        VERSION_WITHOUT_V="${STEPS_RESOLVE_VERSION_OUTPUTS_VERSION_WITHOUT_V}"
+        INSTALL_DIR="${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR}"
+        COMPLETE_MARKER="${RUNNER_TOOL_CACHE}/task/${VERSION_WITHOUT_V}/${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_ARCH}.complete"
 
         if [[ -f "${COMPLETE_MARKER}" && -f "${INSTALL_DIR}/task" && -x "${INSTALL_DIR}/task" ]]; then
           echo "Found cached Task ${VERSION_WITHOUT_V} at ${INSTALL_DIR}"
@@ -107,16 +116,20 @@ runs:
           echo "found=false" >> $GITHUB_OUTPUT
           mkdir -p "${INSTALL_DIR}"
         fi
+      env:
+        STEPS_RESOLVE_VERSION_OUTPUTS_VERSION_WITHOUT_V: ${{ steps.resolve-version.outputs.version-without-v }}
+        STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR: ${{ steps.resolve-install-dir.outputs.install-dir }}
+        STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_ARCH: ${{ steps.resolve-install-dir.outputs.arch }}
 
     - name: Download and verify task
       if: inputs.use-cache != 'true' || steps.check-task.outputs.found != 'true'
       shell: bash
       run: |
-        OS="${{ steps.resolve-install-dir.outputs.os }}"
-        ARCH="${{ steps.resolve-install-dir.outputs.arch }}"
-        INSTALL_DIR="${{ steps.resolve-install-dir.outputs.install-dir }}"
-        TASK_VERSION="${{ steps.resolve-version.outputs.version }}"
-        VERSION_WITHOUT_V="${{ steps.resolve-version.outputs.version-without-v }}"
+        OS="${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_OS}"
+        ARCH="${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_ARCH}"
+        INSTALL_DIR="${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR}"
+        TASK_VERSION="${STEPS_RESOLVE_VERSION_OUTPUTS_VERSION}"
+        VERSION_WITHOUT_V="${STEPS_RESOLVE_VERSION_OUTPUTS_VERSION_WITHOUT_V}"
 
         mkdir -p "${INSTALL_DIR}"
 
@@ -171,15 +184,25 @@ runs:
         touch "${RUNNER_TOOL_CACHE}/task/${VERSION_WITHOUT_V}/${ARCH}.complete"
 
         echo "Installed Task ${TASK_VERSION} to ${INSTALL_DIR}"
+      env:
+        STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_OS: ${{ steps.resolve-install-dir.outputs.os }}
+        STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_ARCH: ${{ steps.resolve-install-dir.outputs.arch }}
+        STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR: ${{ steps.resolve-install-dir.outputs.install-dir }}
+        STEPS_RESOLVE_VERSION_OUTPUTS_VERSION: ${{ steps.resolve-version.outputs.version }}
+        STEPS_RESOLVE_VERSION_OUTPUTS_VERSION_WITHOUT_V: ${{ steps.resolve-version.outputs.version-without-v }}
 
     - name: Add task to PATH
       shell: bash
-      run: |
-        echo "${{ steps.resolve-install-dir.outputs.install-dir }}" >> $GITHUB_PATH
-        echo "task_path=${{ steps.resolve-install-dir.outputs.install-dir }}" >> $GITHUB_OUTPUT
+      run: | # zizmor: ignore[github-env] install-dir is computed from trusted runner paths, validated semver, and fixed arch
+        echo "${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR}" >> $GITHUB_PATH
+        echo "task_path=${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR}" >> $GITHUB_OUTPUT
+      env:
+        STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR: ${{ steps.resolve-install-dir.outputs.install-dir }}
 
     - name: Verify task installation
       shell: bash
       run: |
-        echo "Task installed at: ${{ steps.resolve-install-dir.outputs.install-dir }}"
-        "${{ steps.resolve-install-dir.outputs.install-dir }}/task" --version
+        echo "Task installed at: ${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR}"
+        "${STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR}/task" --version
+      env:
+        STEPS_RESOLVE_INSTALL_DIR_OUTPUTS_INSTALL_DIR: ${{ steps.resolve-install-dir.outputs.install-dir }}


### PR DESCRIPTION
This remediates zizmor findings in the composite action by moving GitHub expression interpolation out of shell run blocks and into step environment variables. It also validates resolved Task versions before using them in tool-cache paths, keeping the intentional PATH update documented with a targeted zizmor ignore.

- Move template expressions from shell scripts into step env variables.
- Validate Task versions as semver before deriving cache and install paths.
- Document the remaining intentional GITHUB_PATH write with an inline zizmor ignore.

Verification: `zizmor action.yml` reports no findings, with one documented ignore and one default-suppressed auditor finding.
