### PR TITLE
fix: harden workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Cached install (${{ matrix.os }})
@@ -13,6 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Task
         uses: ./
       - name: Verify task
@@ -28,6 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Task
         uses: ./
         with:


### PR DESCRIPTION
Harden the test workflow so it passes zizmor without findings. This limits the workflow token to read-only repository contents and avoids persisting checkout credentials in job workspaces.

- Set explicit `contents: read` workflow permissions.
- Disable `persist-credentials` for both checkout steps.

Validation: `zizmor .github/workflows`
