### PR TITLE
chore(dependabot): add update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a Dependabot cooldown to the GitHub Actions update configuration so newly released versions have a short settling period before update PRs are opened. This addresses the zizmor dependabot-cooldown finding while preserving the existing weekly Friday schedule.

- Add a 7-day default cooldown to the Dependabot GitHub Actions update block
- Keep the existing schedule, time, and timezone unchanged
