### PR TITLE
chore: add zizmor taskfile shortcuts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,6 +22,16 @@ vars:
   NEW_MAJOR_VERSION: "v{{.NEXT_MAJOR}}.0.0"
 
 tasks:
+  zizmor:
+    desc: Audit GitHub Actions workflows and action metadata with zizmor
+    cmds:
+      - zizmor .
+
+  fix:
+    desc: Apply safe zizmor auto-fixes
+    cmds:
+      - zizmor --fix=safe .
+
   _preflight:
     internal: true
     desc: Validate branch and remote state before releasing


### PR DESCRIPTION
Adds Taskfile shortcuts for running zizmor against this repository and applying safe auto-fixes. This makes workflow auditing and low-risk remediation available through consistent `task` commands.

- Add `task zizmor` to audit GitHub Actions workflows and action metadata with `zizmor .`
- Add `task fix` to apply safe zizmor auto-fixes with `zizmor --fix=safe .`

